### PR TITLE
added lua-bitop as required by the websocket module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN set -x \
  && apt-get update -qq \
  && apt-get install -qy telnet \
     apt-utils mercurial lua-sec lua-event lua-zlib lua-ldap \
-    lua-dbi-mysql lua-dbi-postgresql lua-dbi-sqlite3 \
+    lua-dbi-mysql lua-dbi-postgresql lua-dbi-sqlite3 lua-bitop \
     prosody${PROSODY_VERSION} \
  && apt-get purge apt-utils -qy \
  && apt-get clean && rm -Rf /var/lib/apt/lists \


### PR DESCRIPTION
It would be nice if I could use the websocket module, but  unfortunately it requires lua-bitop to be installed. So I made a fork, but I'd rather keep using your docker image. I'm using version 0.10 by the way, but the change would probably be the same for the other branches.

see also: https://prosody.im/doc/depends#bitop