### PR TITLE
doc: Dockerfile must be available locally for the build to work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This project was inspired by the [official Prosody Docker](https://github.com/pr
 
 ## Building
 
+First, clone this repository and change directory into `prosody-docker-extended/`. Then run:
+
 ```
 docker build --build-arg PROSODY_VERSION="" --rm=true -t unclev/prosody-docker-extended:stable .
 ```


### PR DESCRIPTION
The Dockerfile must be available for the `build` command to work. This PR explicitly directs the user to have the repo cloned locally before building.